### PR TITLE
FIX db failure and constant missing on PRO edition

### DIFF
--- a/src/custom/src/systemdata/SystemDataAWF.php
+++ b/src/custom/src/systemdata/SystemDataAWF.php
@@ -97,11 +97,13 @@ class SystemDataAWF extends SystemData
         // do we know all the tables? or is there a discrepancy and should we stop?
         $db = \DBManagerFactory::getInstance();
         $current_tables = $db->getTablesArray();
+        $hasAWF = false;
         foreach ($current_tables as $key => $table) {
             if (substr($table, 0, strlen('pmse_')) != 'pmse_') {
                 // remove all tables that are not from awf    
                 unset($current_tables[$key]);
             } else {
+                $hasAWF = true;
                 // verify if we know all of them by removing all the known ones
                 if (!empty($this->modules_not_to_sync[$table]) || !empty($this->modules_to_sync[$table])) {
                     unset($current_tables[$key]);
@@ -109,7 +111,7 @@ class SystemDataAWF extends SystemData
             }
         }
         if (empty($current_tables)) {
-            return true;
+            return $hasAWF;
         } else {
             return false;
         }

--- a/src/custom/src/systemdata/SystemDataRoles.php
+++ b/src/custom/src/systemdata/SystemDataRoles.php
@@ -16,25 +16,25 @@ class SystemDataRoles extends SystemData
         'ACL_ALLOW_DEV',
         'ACL_ALLOW_ALL',
         'ACL_ALLOW_ENABLED',
-        'ACL_ALLOW_SELECTED_TEAMS',
         'ACL_ALLOW_OWNER',
         'ACL_ALLOW_NORMAL',
         'ACL_ALLOW_DEFAULT',
         'ACL_ALLOW_DISABLED',
         'ACL_ALLOW_NONE',
+        'ACL_ALLOW_SELECTED_TEAMS',
     );
     
     public $acl_fields_keywords = array(
         'ACL_READ_ONLY',
         'ACL_READ_WRITE',
-        'ACL_READ_SELECTED_TEAMS_WRITE',
-        'ACL_SELECTED_TEAMS_READ_OWNER_WRITE',
-        'ACL_SELECTED_TEAMS_READ_WRITE',
         'ACL_OWNER_READ_WRITE',
         'ACL_READ_OWNER_WRITE',
         'ACL_ALLOW_NONE',
         'ACL_ALLOW_DEFAULT',
         'ACL_FIELD_DEFAULT',
+        'ACL_READ_SELECTED_TEAMS_WRITE',
+        'ACL_SELECTED_TEAMS_READ_OWNER_WRITE',
+        'ACL_SELECTED_TEAMS_READ_WRITE',
     );
 
     public $acl_module_default = 'ACL_ALLOW_DEFAULT';    


### PR DESCRIPTION
I change the order for constant check instead of use of a `defined` function and I added a check for at last 1 table with pmse_ during Awf verify process. Tell me if you have a different approach in comments

Resolves issue #7 